### PR TITLE
Fixed config commitee typo

### DIFF
--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -10,5 +10,5 @@ export const siteConfigs = {
     instagram: "https://www.instagram.com/acm.ucsd/",
   },
   contactEmail: "hack@acmucsd.org",
-  committee: "hack"
+  committee: "Hack"
 }


### PR DESCRIPTION
open source is my passion

renamed "hack" to "Hack" in config committee since API filters events by committee case-sensitively