### PR TITLE
Fix workshop links

### DIFF
--- a/src/assets/hackevents.json
+++ b/src/assets/hackevents.json
@@ -16,7 +16,7 @@
             "staffPointBonus": 0,
             "virtual": true,
             "github": "https://acmurl.com/gql-code",
-            "facebook": "https://fb.me/e/4GZqyoXj2"
+            "facebook": "https://fb.me/e/4GF0j7Zw1"
         },
         {
             "uuid": "6",
@@ -33,7 +33,7 @@
             "requiresStaff": false,
             "staffPointBonus": 0,
             "virtual": true,
-            "facebook": "https://fb.me/e/4GZqyoXj2"
+            "facebook": "https://fb.me/e/1r4VMGSGd"
         }
     ],
     "hack.py": [

--- a/src/assets/hackevents.json
+++ b/src/assets/hackevents.json
@@ -53,7 +53,7 @@
             "staffPointBonus": 0,
             "virtual": true,
             "github": "http://acmurl.com/hackpy",
-            "facebook": "https://fb.me/e/4GZqyoXj2"
+            "facebook": "https://fb.me/e/3vewKO8En"
         },
         {
             "uuid": "6",
@@ -71,7 +71,7 @@
             "staffPointBonus": 0,
             "virtual": true,
             "github": "http://acmurl.com/hackpy",
-            "facebook": "https://fb.me/e/4GZqyoXj2"
+            "facebook": "https://fb.me/e/9FBhl0mXa"
         },
         {
             "uuid": "6",
@@ -89,7 +89,7 @@
             "staffPointBonus": 0,
             "virtual": true,
             "github": "http://acmurl.com/hackpy",
-            "facebook": "https://fb.me/e/4GZqyoXj2"
+            "facebook": "https://fb.me/e/4J76ZwWKB"
         },
         {
             "uuid": "6",
@@ -107,7 +107,7 @@
             "staffPointBonus": 0,
             "virtual": true,
             "github": "http://acmurl.com/hackpy",
-            "facebook": "https://fb.me/e/4GZqyoXj2"
+            "facebook": ""
         },
         {
             "uuid": "6",
@@ -125,7 +125,7 @@
             "staffPointBonus": 0,
             "virtual": true,
             "github": "http://acmurl.com/hackpy",
-            "facebook": "https://fb.me/e/4GZqyoXj2"
+            "facebook": ""
         },
         {
             "uuid": "6",
@@ -143,7 +143,7 @@
             "staffPointBonus": 0,
             "virtual": true,
             "github": "http://acmurl.com/hackpy",
-            "facebook": "https://fb.me/e/4GZqyoXj2"
+            "facebook": ""
         },
         {
             "uuid": "6",
@@ -161,7 +161,7 @@
             "staffPointBonus": 0,
             "virtual": true,
             "github": "http://acmurl.com/hackpy",
-            "facebook": "https://fb.me/e/4GZqyoXj2"
+            "facebook": ""
         }
     ],
     "hackschool": [


### PR DESCRIPTION
Fixed the workshop links for hack.py and others, which used to link to the Hackschool FB event. Hack.py workshops without FB events don't link anywhere for now.